### PR TITLE
Decode public key hash in HEX format from valcons bech32 address

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,30 +90,6 @@ the script on start-up.
 | `delegator_address` | Reward wallet address associated with validator. | `<simd> keys show -a <wallet>`            |
 | `validator_address` | Node's validator address to query information.   | `<simd> keys show -a --bech val <wallet>` |
 
-### Optional arguments
-
-| Option                  | Description                                           |
-|-------------------------|-------------------------------------------------------|
-| `validator_hex_address` | Validator node HEX address to check uptime and ranks. |
-
-### Notable arguments
-
-The `validator_hex_address` argument needed to override automatically discovered
-node's HEX address in case the script will be connected not directly to validator
-node's API endpoint, but to a full node. This can be useful to avoid exposing API
-port on validator node and/or starting API service at all.
-
-For sure, it will be nice to be able to query it via API/RCP or calculate from the
-rest of arguments (such as `validator_address`), but currently such functional not
-implemented (yet).
-
-You can query your validator node HEX address by running the next command locally
-on the node (please adjust RPC address and port according to your configuration):
-
-```bash
-curl -s localhost:26657/status | jq -r .result.validator_info.address
-```
-
 ## Examples
 
 ### Running as container

--- a/cosmos_exporter
+++ b/cosmos_exporter
@@ -13,6 +13,17 @@ BOND_STATUSES = {
     'BOND_STATUS_UNBONDED': 2,
 }
 
+code_strings = {
+    2: b'01',
+    3: b' ,.',
+    10: b'0123456789',
+    16: b'0123456789abcdef',
+    32: b'abcdefghijklmnopqrstuvwxyz234567',
+    58: b'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz',
+    256: b''.join([bytes((csx,)) for csx in range(256)]),
+    'bech32': b'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
+}
+
 balances_available_total = Gauge(
     name='balances_available_total',
     documentation='Total balances available to use across all balances',
@@ -212,6 +223,128 @@ class Validator(object):
         for commission in api.commission(validator_address=self.validator_address):
             total += float(commission['amount'])
         return total / 10 ** 6
+
+
+def _bech32_polymod(values):
+    """
+    Internal function that computes the Bech32 checksum
+
+    Source: https://github.com/1200wd/bitcoinlib/blob/9507fbd035263cba5904bf0fdbb7f84bf549ffc0/bitcoinlib/encoding.py
+    """
+    generator = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]
+    chk = 1
+    for value in values:
+        top = chk >> 25
+        chk = (chk & 0x1ffffff) << 5 ^ value
+        for i in range(5):
+            chk ^= generator[i] if ((top >> i) & 1) else 0
+    return chk
+
+
+def addr_bech32_to_pubkeyhash(bech, prefix=None, include_witver=False, as_hex=False):
+    """
+    Decode bech32 / segwit address to public key hash
+
+    Source: https://github.com/1200wd/bitcoinlib/blob/9507fbd035263cba5904bf0fdbb7f84bf549ffc0/bitcoinlib/encoding.py
+
+    >>> addr_bech32_to_pubkeyhash('bc1qy8qmc6262m68ny0ftlexs4h9paud8sgce3sf84', as_hex=True)
+    '21c1bc695a56f47991e95ff26856e50f78d3c118'
+
+    Validate the bech32 string, and determine HRP and data. Only standard data size of 20 and 32 bytes are excepted
+
+    :param bech: Bech32 address to convert
+    :type bech: str
+    :param prefix: Address prefix called Human-readable part. Default is None and tries to derive prefix, for bitcoin specify 'bc' and for bitcoin testnet 'tb'
+    :type prefix: str
+    :param include_witver: Include witness version in output? Default is False
+    :type include_witver: bool
+    :param as_hex: Output public key hash as hex or bytes. Default is False
+    :type as_hex: bool
+
+    :return str: Public Key Hash
+    """
+    if (any(ord(x) < 33 or ord(x) > 126 for x in bech)) or (bech.lower() != bech and bech.upper() != bech):
+        raise Exception("Invalid bech32 character in bech string")
+    bech = bech.lower()
+    pos = bech.rfind('1')
+    if pos < 1 or pos + 7 > len(bech) or len(bech) > 90:
+        raise Exception("Invalid bech32 string length")
+    if prefix and prefix != bech[:pos]:
+        raise Exception("Invalid bech32 address. Prefix '%s', prefix expected is '%s'" % (bech[:pos], prefix))
+    else:
+        hrp = bech[:pos]
+    data = _codestring_to_array(bech[pos + 1:], 'bech32')
+    hrp_expanded = [ord(x) >> 5 for x in hrp] + [0] + [ord(x) & 31 for x in hrp]
+    if not _bech32_polymod(hrp_expanded + data) == 1:
+        raise Exception("Bech polymod check failed")
+    data = data[:-6]
+    decoded = bytes(convertbits(data, 5, 8, pad=False))
+    if decoded is None or len(decoded) < 2 or len(decoded) > 20:
+        raise Exception("Invalid decoded data length, must be between 2 and 40")
+    if data[0] > 20:
+        raise Exception("Invalid decoded data length")
+    if data[0] == 0 and len(decoded) not in [20, 32]:
+        raise Exception("Invalid decoded data length, must be 20 or 32 bytes")
+    prefix = b''
+    if include_witver:
+        datalen = len(decoded)
+        prefix = bytes([data[0] + 0x50 if data[0] else 0, datalen])
+    if as_hex:
+        return (prefix + decoded).hex()
+    return prefix + decoded
+
+
+def _codestring_to_array(codestring, base):
+    """
+    Source: https://github.com/1200wd/bitcoinlib/blob/9507fbd035263cba5904bf0fdbb7f84bf549ffc0/bitcoinlib/encoding.py
+    """
+    codestring = bytes(codestring, 'utf8')
+    codebase = code_strings[base]
+    array = []
+    for s in codestring:
+        try:
+            array.append(codebase.index(s))
+        except ValueError:
+            raise Exception("Character '%s' not found in codebase" % s)
+    return array
+
+
+def convertbits(data, frombits, tobits, pad=True):
+    """
+    'General power-of-2 base conversion'
+
+    Source: https://github.com/sipa/bech32/tree/master/ref/python
+
+    :param data: Data values to convert
+    :type data: list
+    :param frombits: Number of bits in source data
+    :type frombits: int
+    :param tobits: Number of bits in result data
+    :type tobits: int
+    :param pad: Use padding zero's or not. Default is True
+    :type pad: bool
+
+    :return list: Converted values
+    """
+    acc = 0
+    bits = 0
+    ret = []
+    maxv = (1 << tobits) - 1
+    max_acc = (1 << (frombits + tobits - 1)) - 1
+    for value in data:
+        if value < 0 or (value >> frombits):
+            return None
+        acc = ((acc << frombits) | value) & max_acc
+        bits += frombits
+        while bits >= tobits:
+            bits -= tobits
+            ret.append((acc >> bits) & maxv)
+    if pad:
+        if bits:
+            ret.append((acc << (tobits - bits)) & maxv)
+    elif bits >= frombits or ((acc << (tobits - bits)) & maxv):
+        return None
+    return ret
 
 
 def parse_arguments():

--- a/cosmos_exporter
+++ b/cosmos_exporter
@@ -367,9 +367,6 @@ def parse_arguments():
     parser.add_argument('--rpc_url', help='Tendermint instance RPC endpoint URL', type=str,
                         default='http://127.0.0.1:26657')
     parser.add_argument('--validator_address', help='The validator address to query stats', type=str, required=True)
-    parser.add_argument(
-        '--validator_hex_address', help='The validator HEX address to query uptime and ranks', type=str, default=str()
-    )
     parser.add_argument('--uptime_window', help='Number of blocks to calculate node uptime', type=int, default=100)
     return parser
 
@@ -416,13 +413,6 @@ def metrics(interval: int) -> float:
     logging.info('start')
     val = Validator(validator_address=known_args.validator_address)
     status = api.status()
-    # NOTE: In case the script will be connected to a full node, it is required to manually provide validator node's
-    #       address in HEX format. For sure, it will be nice to be able to query it via API/RCP or calculate from
-    #       existing arguments (such as validator_address), but currently such functional is not yet implemented.
-    # TODO: Keep tracking https://github.com/cosmos/cosmos-sdk/pull/8567 and remove validator_hex_address usage once
-    #       Cosmos SDK version will be upgraded to version containing already merged patch from this pull request.
-    if known_args.validator_hex_address:
-        status['validator_info']['address'] = known_args.validator_hex_address
     validator_jailed.labels(
         validator_address=val.validator_address,
         chain_id=status['node_info']['network'],
@@ -441,12 +431,12 @@ def metrics(interval: int) -> float:
     ).set(val.commissions())
     validators = api.validators_set()
     priority(
-        address=status['validator_info']['address'],
+        address=validator_hex_address,
         chain_id=status['node_info']['network'],
         validators=validators,
     )
     rank(
-        address=status['validator_info']['address'],
+        address=validator_hex_address,
         chain_id=status['node_info']['network'],
         validators=validators,
     )
@@ -478,7 +468,7 @@ def metrics(interval: int) -> float:
         chain_id=status['node_info']['network'],
     ).set(
         uptime(
-            address=status['validator_info']['address'],
+            address=validator_hex_address,
             last_commit_height=int(status['sync_info']['latest_block_height']) - 1,
             uptime_window=known_args.uptime_window,
         )
@@ -502,6 +492,11 @@ if __name__ == '__main__':
     known_args, unknown_args = parse_arguments().parse_known_args()
     logging.basicConfig(level=logging.getLevelName(known_args.log_level.upper()))
     start_http_server(addr=known_args.host, port=known_args.port)
+    # TODO: Keep tracking https://github.com/cosmos/cosmos-sdk/pull/8567 and remove use of public key hash in HEX format
+    validator_hex_address = addr_bech32_to_pubkeyhash(
+        bech=known_args.consensus_address,
+        as_hex=True
+    ).upper()
     api = CosmosRest(
         api_url=known_args.api_url,
         rpc_url=known_args.rpc_url,


### PR DESCRIPTION
From now, validator node HEX address will be computed based on the `consensus_address` argument which accepts `bech32` `valcons` value.

Actually, backported functions do operation equivalent to the next CLI operation:

```bash
kid keys parse tkivalcons158ms2lcacdtu78270uef9ayth7lfkuvxq4lnms
```

Thanks to https://github.com/1200wd/bitcoinlib/blob/9507fbd035263cba5904bf0fdbb7f84bf549ffc0/bitcoinlib/encoding.py and sources mentioned there: code copied from `bitcoinlib` module works with Cosmos with a very small number of changes.